### PR TITLE
Features support Agent Smith

### DIFF
--- a/src/pysteamcmd/steamcmd.py
+++ b/src/pysteamcmd/steamcmd.py
@@ -64,12 +64,13 @@ class Steamcmd(object):
             raise SteamcmdException('An unknown exception occurred! {}'.format(e))
 
     def _extract_steamcmd(self):
+        steamcmd_full_path = os.path.join(self.download_path, self.steamcmd_zip)
         if self.platform == 'Windows':
-            with zipfile.ZipFile(self.steamcmd_zip, 'r') as f:
+            with zipfile.ZipFile(steamcmd_full_path, 'r') as f:
                 return f.extractall(self.install_path)
 
         elif self.platform == 'Linux':
-            with tarfile.open(self.steamcmd_zip, 'r:gz') as f:
+            with tarfile.open(steamcmd_full_path, 'r:gz') as f:
                 return f.extractall(self.install_path)
 
         else:
@@ -135,6 +136,18 @@ class Steamcmd(object):
             return subprocess.check_call(steamcmd_params)
         except subprocess.CalledProcessError:
             raise SteamcmdException("Steamcmd was unable to run. Did you install your 32-bit libraries?")
+
+    def update_gamefiles(self, gameid, game_install_dir, user='anonymous', password=None, validate=False):
+        """
+        Updates gamefiles for dedicated server. This can also be used to update the gameserver.
+        :param gameid: steam game id for the files downloaded
+        :param game_install_dir: installation directory for gameserver files
+        :param user: steam username (defaults anonymous)
+        :param password: steam password (defaults None)
+        :param validate: should steamcmd validate the gameserver files (takes a while)
+        :return: subprocess call to steamcmd
+        """
+        return self.install_gamefiles(gameid, game_install_dir, user=user, password=password, validate=validate)
 
     def install_workshopfiles(self, gameid, workshop_id, game_install_dir, user='anonymous', password=None,
                               validate=False):

--- a/src/pysteamcmd/steamcmd.py
+++ b/src/pysteamcmd/steamcmd.py
@@ -23,13 +23,17 @@ class SteamcmdException(Exception):
 
 
 class Steamcmd(object):
-    def __init__(self, install_path):
+    def __init__(self, install_path, download_path):
         """
         :param install_path: installation path for steamcmd
         """
         self.install_path = install_path
         if not os.path.isdir(self.install_path):
             raise SteamcmdException('Install path is not a directory or does not exist: {}'.format(self.install_path))
+
+        self.download_path = download_path
+        if not os.path.isdir(self.install_path):
+            raise SteamcmdException('Download path is not a directory or does not exist: {}'.format(self.install_path))
 
         self.platform = platform.system()
         if self.platform == 'Windows':
@@ -47,9 +51,15 @@ class Steamcmd(object):
                 'The operating system is not supported. Expected Linux or Windows, received: {}'.format(self.platform)
             )
 
-    def _download_steamcmd(self):
+    def _download_steamcmd(self, destination_path: str = None):
         try:
-            return urlretrieve(self.steamcmd_url, self.steamcmd_zip)
+
+            if destination_path:
+                download_to_path = os.path.join(destination_path, self.steamcmd_zip)
+            else:
+                download_to_path = self.steamcmd_zip
+
+            return urlretrieve(self.steamcmd_url, download_to_path)
         except Exception as e:
             raise SteamcmdException('An unknown exception occurred! {}'.format(e))
 
@@ -75,16 +85,17 @@ class Steamcmd(object):
             return vdf.parse(vdf_data)
         return None
 
-    def install(self, force=False):
+    def install(self, force: bool = False):
         """
         Installs steamcmd if it is not already installed to self.install_path.
+        :param steamcmd_dl_path: Designate where steamcmd zip/tarball gets downloaded to.
         :param force: forces steamcmd install regardless of its presence
         :return:
         """
         if not os.path.isfile(self.steamcmd_exe) or force is True:
             # Steamcmd isn't installed. Go ahead and install it.
             try:
-                self._download_steamcmd()
+                self._download_steamcmd(destination_path=self.download_path)
             except SteamcmdException as e:
                 return e
 


### PR DESCRIPTION
Add ability to specify where the initial zipfile of steamcmd gets downloaded to.  
That way Agent Smith doesn't wind up downloading it next to the agent-smith.exe

Add ability to update a game, but its basically the same command as installation so little difference. Just a specific function. 

Closes https://github.com/agentsofthesystem/agent-smith/issues/32 